### PR TITLE
Summarize over time frames

### DIFF
--- a/src/components/multi_chart.js
+++ b/src/components/multi_chart.js
@@ -76,11 +76,9 @@ class SingleChart extends React.Component {
                     lineTension: 0.1,
                     backgroundColor: this.props.color[i],
                     borderColor: this.props.color[i],
-                    borderCapStyle: "butt",
                     borderDash: [],
-                    pointHitRadius: 10,
+                    pointHitRadius: 30,
                     borderDashOffset: 0.0,
-                    borderJoinStyle: "miter",
                     pointRadius: 0,
                     data: v.map(x => {
                         return {

--- a/src/components/single_chart.js
+++ b/src/components/single_chart.js
@@ -41,8 +41,8 @@ class SingleChart extends React.Component {
                     fill: false,
                     backgroundColor: props.color,
                     borderColor: props.color,
-                    pointHitRadius: 10,
-                    borderJoinStyle: "miter",
+                    pointHitRadius: 30,
+                    barThickness: "flex",
                     pointRadius: 0,
                     data: []
                 }
@@ -110,7 +110,10 @@ class SingleChart extends React.Component {
         let formattedSubtitle = this.props.subtitle;
 
         if (formattedSubtitle) {
-            formattedSubtitle = formattedSubtitle.replace("$interval", duration.format("d [days], h [hours] [and] mm [minutes]"));
+            formattedSubtitle = formattedSubtitle.replace("$interval", duration.format({
+                template: "d [days], h [hours], mm [minutes]",
+                trim: "both"
+            }));
 
             this.setState({
                 formattedSubtitle


### PR DESCRIPTION
This summarises over time frames leading to nicer consistent interval instead of like "1 hour and 50 minutes".

There are a other few UX changes like expanding the bars on in use help channel to fit the interval so they have a more hoverable radius. As well as this the point hover radius has increased so the cursor does not have to touch a line as closely to get a tooltip trigger.

On the Python side of things a huge removal of duplicated code has been done, docstrings have been rewritten and utility functions for single metric and multi-metric queries have been written.