### PR TITLE
Implement Caching

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,12 +1,10 @@
-import copy
-import json
 import os
 from collections import defaultdict
 from datetime import datetime
 from functools import wraps
 
 import httpx
-from flask import Flask, jsonify, make_response, Response, request
+from flask import Flask, make_response, Response, request
 
 app = Flask(__name__, static_folder="../build", static_url_path="/")
 

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -16,7 +16,7 @@ GRAPHITE_HOST = (os.environ.get("GRAPHITE_HOST") or "http://graphite:80") + "/re
 TIME_FRAMES = {"day": "-24h", "week": "-1w", "month": "-1mon", "year": "-1y"}
 SUMMARIZE = {"day": "15minute", "week": "30minute", "month": "12hour", "year": "1day"}
 
-CACHE_THRESHOLD = 10
+CACHE_THRESHOLD = 300
 CACHED = defaultdict(lambda: (datetime.fromtimestamp(0), None))
 
 

--- a/src/components/multi_chart.js
+++ b/src/components/multi_chart.js
@@ -69,7 +69,7 @@ class SingleChart extends React.Component {
         let self = this;
         let path = this.props.path + "?frame=" + timeFrameStore.getState();
         fetch(path).then(resp => resp.json()).then((data) => {
-            this.data.datasets = data.map((v, i) => {
+            this.data.datasets = data["data"].map((v, i) => {
                 return {
                     label: this.props.names[i],
                     fill: this.props.stacked,

--- a/src/components/single_chart.js
+++ b/src/components/single_chart.js
@@ -94,7 +94,7 @@ class SingleChart extends React.Component {
         let self = this;
         let path = this.props.path + "?frame=" + timeFrameStore.getState();
         fetch(path).then(resp => resp.json()).then((data) => {
-            this.data.datasets[0].data = data.map(x => {
+            this.data.datasets[0].data = data["data"].map(x => {
                 return {
                     x: new Date(x[1] * 1000),
                     y: Math.round(x[0])


### PR DESCRIPTION
This PR achieves two forms of caching:
- Assign correct cache control headers to force downstream cache systems to retain response data
- Add an internal cache for graphite queries to ensure that data is cached for a maximum of 300 seconds until a new query is run, both improving speed and resource utilisation.