### PR TITLE
Dockerized - Multi-stage docker + docker-compose. A double whammy!

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,3 @@
-
 name: Linting
 
 on:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,22 @@
-FROM python:3.8.3-alpine
+# Stage 1: Build the HTML
+FROM node:14.8.0-stretch AS builder
+COPY . .
+RUN npm install && yarn build && yarn cache clean
 
+# Stage 2: Set up the backend
+FROM python:3.8-slim
 STOPSIGNAL SIGQUIT
 
-WORKDIR /app
+# Install all dependencies
 COPY requirements.txt .
-
 RUN pip install -r requirements.txt
 
+# Copy the HTML from Stage 1
+COPY --from=builder /build /app/build
+
+# Copy files into the /app directory
+WORKDIR /app
 COPY . .
 
+# Start the server with gunicorn
 CMD ["gunicorn", "-b", "0.0.0.0:8000", "--workers", "2", "app:app", "--access-logfile", "-"]

--- a/README.md
+++ b/README.md
@@ -1,23 +1,29 @@
 # Python Discord public statistics
 
-Public statistics for the Discord server available at https://stats.pydis.com.
+Public statistics for the Discord server available at https://stats.pydis.com
 
-## Setup
+## Running locally with docker-compose
+If you're running this locally, the easiest way is to just use `docker-compose`. We've provided a `docker-compose` file that will first start up Graphite, and then build and launch the app.
+
+In order to get the app running, all you need to do is:
+```shell script
+docker-compose up
+``` 
+
+## Setting up for production
 
 ### Graphite
-
-Graphite must be accessible at the location set in `GRAPHITE_HOST`..
+The app expects Graphite to be accessible at the location set in the `GRAPHITE_HOST` environment variable.
 
 ### React
-
 The debug react server can be started with `yarn start`. By default it will proxy requests it does not understand to port 5000 where Flask is running.
 
 ### Flask
-
 The flask backend can be started with `python -m api`.
 
 ### Building
-
-To build the HTML files for production use `yarn build`.
+To build the HTML files for production use `npm install && yarn build`.
 
 **You must build the HTML before the Docker image, the HTML must be inside the Docker image so Flask can serve it.**
+
+By default, the app expects to find the HTML inside `/app/build/*`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3.7"
+services:
+  graphite:
+    container_name: public-stats-graphite
+    image: graphiteapp/graphite-statsd:latest
+    ports:
+      - 8899:80
+      - 8125:8125
+  public-stats:
+    depends_on:
+      - graphite
+    container_name: public-stats
+    image: ghcr.io/python-discord/public-stats:latest
+    ports:
+     - 8898:8000
+    environment:
+      - GRAPHITE_HOST=public-stats-graphite
+    build:
+      context: .
+      dockerfile: Dockerfile

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "pdstats",
+  "version": "0.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "yarn": {
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.10.tgz",
+      "integrity": "sha512-IanQGI9RRPAN87VGTF7zs2uxkSyQSrSPsju0COgbsKQOOXr5LtcVPeyXWgwVa0ywG3d8dg6kSYKGBuYK021qeA=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "react-dom": "^16.13.1",
     "react-dropdown": "^1.7.0",
     "react-scripts": "3.4.1",
-    "redux": "^4.0.5"
+    "redux": "^4.0.5",
+    "yarn": "^1.22.10"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
This PR adds some pretty nice improvements.
- We're now building the entire app (including the HTML) inside the Dockerfile by using multi-staging.
- I've added a docker-compose that sets up Graphite, so that all you need to do to test the app is just `docker-compose up`
- Added some nice ~~dockermentation~~ documentation for the new features
- **EXORCISED AN EVIL NEWLINE**